### PR TITLE
Test Coverage 100%

### DIFF
--- a/src/backbone.eventrouter.js
+++ b/src/backbone.eventrouter.js
@@ -219,7 +219,8 @@ var EventRouter = Backbone.EventRouter = Backbone.Router.extend({
 
     // if no matching route exists do nothing
     if(!route) {
-      this.trigger.apply(this, ['noMatch'].concat(arguments));
+      var args = _.drop(arguments, 0);
+      this.trigger.apply(this, ['noMatch'].concat(args));
       return this;
     }
 

--- a/test/unit/api.js
+++ b/test/unit/api.js
@@ -1,0 +1,151 @@
+describe('Backbone.Eventrouter API', function() {
+  beforeEach(function() {
+    this.Location = function(href) {
+      this.replace(href);
+    };
+
+    _.extend(this.Location.prototype, {
+      parser: document.createElement('a'),
+      replace: function(href) {
+        this.parser.href = href;
+        _.extend(this, _.pick(this.parser,
+                              'href',
+                              'hash',
+                              'host',
+                              'search',
+                              'fragment',
+                              'pathname',
+                              'protocol'
+                             ));
+        // In IE, anchor.pathname does not contain a leading slash though
+        // window.location.pathname does.
+        if (!/^\//.test(this.pathname)){
+          this.pathname = '/' + this.pathname;
+        }
+      },
+      toString: function() {
+        return this.href;
+      }
+    });
+  });
+
+  afterEach(function() {
+    Backbone.history.stop();
+  });
+
+  describe('when #getChannel', function() {
+    beforeEach(function() {
+      var router = new Backbone.EventRouter({
+        channelName: 'my-event-channel'
+      });
+
+      this.routerChannel = router.getChannel();
+      this.fooStub = this.sinon.stub();
+
+      this.routerChannel.on('foo', this.fooStub);
+    });
+
+    it('should return the same channel that was defined', function() {
+      Backbone.Radio.trigger('my-event-channel', 'foo');
+
+      expect(this.fooStub).to.have.been.calledOnce;
+    });
+  });
+
+  describe('when #addRouteTrigger', function() {
+    beforeEach(function() {
+      Backbone.history.location = new this.Location('http://example.com/example');
+      this.myEventRouter = new Backbone.EventRouter();
+
+      this.fooStub = this.sinon.stub();
+      Backbone.history.start();
+    });
+
+    describe('when defining a route trigger', function() {
+      beforeEach(function() {
+        var routerChannel = this.myEventRouter.getChannel();
+        routerChannel.on('testevent:bar', this.fooStub);
+        this.myEventRouter.addRouteTrigger('test/url/:foo', 'testevent:bar');
+        this.myEventRouter.navigate('test/url/baz', { trigger: true });
+      });
+
+      it('should trigger the appropriate event', function(){
+        expect(this.fooStub).to.have.been.calledOnce;
+      });
+
+      it('should pass the correct arguments', function(){
+        expect(this.fooStub).to.have.been.calledWith('baz');
+      });
+    });
+
+    describe('when defining a route trigger with an array of routes', function() {
+      beforeEach(function() {
+        var routerChannel = this.myEventRouter.getChannel();
+        routerChannel.on('testevent:bar', this.fooStub);
+        this.myEventRouter.addRouteTrigger(['test/url/:foo', 'thing/that/isdifferent'], 'testevent:bar');
+        this.myEventRouter.navigate('test/url/baz', { trigger: true });
+        this.myEventRouter.navigate('thing/that/isdifferent', { trigger: true });
+      });
+
+      it('should trigger the appropriate event in the array', function(){
+        expect(this.fooStub).to.have.been.calledTwice;
+      });
+
+      it('should pass the correct arguments', function(){
+        expect(this.fooStub).to.have.been.calledWith('baz');
+        expect(this.fooStub).to.have.been.calledWith();
+      });
+    });
+  });
+
+  describe('when #getDefaultRoute', function() {
+    beforeEach(function() {
+      this.myEventRouter = new Backbone.EventRouter();
+    });
+
+    it('should have a default route as first route in an array of routes', function(){
+      this.myEventRouter.addRouteTrigger(['some/url/:original', 'some/url', 'another/thing/:id'], 'some:event');
+
+      expect(this.myEventRouter.getDefaultRoute('some:event')).to.eql('some/url/:original');
+    });
+
+    it('should be called with passed-in event', function(){
+      this.myEventRouter.addRouteTrigger('other/:param', 'other:thing');
+
+      expect(this.myEventRouter.getDefaultRoute('other:thing')).to.eql('other/:param');
+    });
+  });
+
+  describe('when #navigateFromEvent', function(){
+    beforeEach(function() {
+      this.myEventRouter = new Backbone.EventRouter({
+        routeTriggers: {
+          'bar:event': ['some/url/:param', 'some/url', 'other/:section/:id'],
+          'thing:list': 'other/:param'
+        }
+      });
+
+      Backbone.history.location = new this.Location('http://example.com/example');
+      Backbone.history.start();
+    });
+
+    it('should translate event to URL', function(){
+      this.myEventRouter.navigateFromEvent('bar:event', 'foo');
+
+      expect(Backbone.history.location.hash).to.equal('#some/url/foo');
+    });
+
+  });
+
+  describe('when #translatedRoute', function() {
+    beforeEach(function() {
+      this.myEventRouter = new Backbone.EventRouter();
+    });
+
+    it('should return a url with the named params replaced with the argument values', function(){
+      var translatedRoute = this.myEventRouter.translateRoute('some/url/:param/:id', ['foo', 22]);
+      expect(translatedRoute).to.eql('some/url/foo/22');
+    });
+  });
+
+});

--- a/test/unit/eventrouter.js
+++ b/test/unit/eventrouter.js
@@ -34,9 +34,7 @@ describe('Backbone.Eventrouter', function() {
   });
 
   describe('when defining a channel name', function() {
-
     describe('on the definition', function() {
-
       it('should set the channel', function() {
         var MyEventRouter = Backbone.EventRouter.extend({
           channelName: function(){ return 'foo'; }
@@ -46,11 +44,9 @@ describe('Backbone.Eventrouter', function() {
 
         expect(this.myEventRouter.getChannel().channelName).to.eql('foo');
       });
-
     });
 
     describe('as an option during construction', function() {
-
       it('should set the channel', function() {
         this.myEventRouter = new Backbone.EventRouter({
           channelName: 'foo'
@@ -58,104 +54,119 @@ describe('Backbone.Eventrouter', function() {
 
         expect(this.myEventRouter.getChannel().channelName).to.eql('foo');
       });
-
     });
-
   });
 
-  describe('when adding route trigger', function() {
+  describe('when defining a routeTriggers', function() {
     beforeEach(function() {
-      Backbone.history.location = new this.Location('http://example.com/example');
-      this.myEventRouter = new Backbone.EventRouter();
+      this.routeTriggers = {
+        'bar:event': ['some/url/:param', 'some/url', 'other/:section/:id'],
+        'thing:list': 'other/:param'
+      };
 
-      this.fooStub = this.sinon.stub();
+      this.addRouteTriggerStub = this.sinon.stub();
+
+      this.EventRouter = Backbone.EventRouter.extend({
+        _addRouteTrigger: this.addRouteTriggerStub
+      });
+    });
+
+    describe('when defining routeTriggers as a hash', function() {
+      beforeEach(function() {
+        this.MyEventRouter = this.EventRouter.extend({
+          routeTriggers: this.routeTriggers
+        });
+        this.myEventRouter = new this.MyEventRouter();
+      });
+
+      it('should add each route in the hash', function() {
+        expect(this.addRouteTriggerStub).to.have.been.calledTwice;
+      });
+
+      it('should add each route(s) by the correct trigger', function() {
+        expect(this.addRouteTriggerStub)
+          .to.have.been.calledWith(this.routeTriggers['bar:event'], 'bar:event');
+        expect(this.addRouteTriggerStub)
+          .to.have.been.calledWith(this.routeTriggers['thing:list'], 'thing:list');
+      });
+    });
+
+    describe('when defining routeTriggers as a function', function() {
+      beforeEach(function() {
+        this.MyEventRouter = this.EventRouter.extend({
+          routeTriggers: _.constant(this.routeTriggers)
+        });
+        this.myEventRouter = new this.MyEventRouter();
+      });
+
+      it('should add each route in the hash', function() {
+        expect(this.addRouteTriggerStub).to.have.been.calledTwice;
+      });
+
+      it('should add each route(s) by the correct trigger', function() {
+        expect(this.addRouteTriggerStub)
+          .to.have.been.calledWith(this.routeTriggers['bar:event'], 'bar:event');
+        expect(this.addRouteTriggerStub)
+          .to.have.been.calledWith(this.routeTriggers['thing:list'], 'thing:list');
+      });
+    });
+
+    describe('when defining routeTriggers as instantiation option', function() {
+      beforeEach(function() {
+        this.MyEventRouter = this.EventRouter.extend();
+        this.myEventRouter = new this.MyEventRouter({
+          routeTriggers: this.routeTriggers
+        });
+      });
+
+      it('should add each route in the hash', function() {
+        expect(this.addRouteTriggerStub).to.have.been.calledTwice;
+      });
+
+      it('should add each route(s) by the correct trigger', function() {
+        expect(this.addRouteTriggerStub)
+          .to.have.been.calledWith(this.routeTriggers['bar:event'], 'bar:event');
+        expect(this.addRouteTriggerStub)
+          .to.have.been.calledWith(this.routeTriggers['thing:list'], 'thing:list');
+      });
+    });
+  });
+
+  describe('when calling overridden backbone.router#route', function() {
+    beforeEach(function() {
+      this.eventHandlerStub = this.sinon.stub();
+      this.callbackStub = this.sinon.stub();
+
+      this.MyEventRouter = Backbone.EventRouter.extend({
+        eventHandler: this.eventHandlerStub
+      });
+
+      this.myEventRouter = new this.MyEventRouter();
+
       Backbone.history.start();
     });
 
-    describe('when defining a route trigger', function() {
+    describe('when not passing a name', function() {
       beforeEach(function() {
-        var routerChannel = this.myEventRouter.getChannel();
-        routerChannel.on('testevent:bar', this.fooStub);
-        this.myEventRouter.addRouteTrigger('test/url/:foo', 'testevent:bar');
-        this.myEventRouter.navigate('test/url/baz', { trigger: true });
+        this.myEventRouter.route('some/url/:param', this.callbackStub);
+        this.myEventRouter.navigate('some/url/foo', { trigger: true });
       });
 
-      it('should trigger the appropriate event', function(){
-        expect(this.fooStub).to.have.been.calledOnce;
+      it('should create the route with name as an empty string', function() {
+        expect(this.callbackStub).to.have.been.calledWith('foo');
       });
 
-      it('should pass the correct arguments', function(){
-        expect(this.fooStub).to.have.been.calledWith('baz');
-      });
     });
 
-    describe('when defining a route trigger with an array of routes', function() {
+    describe('when not passing a callback', function() {
       beforeEach(function() {
-        var routerChannel = this.myEventRouter.getChannel();
-        routerChannel.on('testevent:bar', this.fooStub);
-        this.myEventRouter.addRouteTrigger(['test/url/:foo', 'thing/that/isdifferent'], 'testevent:bar');
-        this.myEventRouter.navigate('test/url/baz', { trigger: true });
-        this.myEventRouter.navigate('thing/that/isdifferent', { trigger: true });
+        this.myEventRouter.route('some/url/:param', 'eventHandler');
+        this.myEventRouter.navigate('some/url/foo', { trigger: true });
       });
 
-      it('should trigger the appropriate event in the array', function(){
-        expect(this.fooStub).to.have.been.calledTwice;
+      it('should create the route with the callback as this[name]', function() {
+        expect(this.eventHandlerStub).to.have.been.calledWith('foo');
       });
-
-      it('should pass the correct arguments', function(){
-        expect(this.fooStub).to.have.been.calledWith('baz');
-        expect(this.fooStub).to.have.been.calledWith();
-      });
-    });
-  });
-
-  describe('when getting default route', function() {
-    beforeEach(function() {
-      this.myEventRouter = new Backbone.EventRouter();
-    });
-
-    it('should have a default route as first route in an array of routes', function(){
-      this.myEventRouter.addRouteTrigger(['some/url/:original', 'some/url', 'another/thing/:id'], 'some:event');
-
-      expect(this.myEventRouter.getDefaultRoute('some:event')).to.eql('some/url/:original');
-    });
-
-    it('should be called with passed-in event', function(){
-      this.myEventRouter.addRouteTrigger('other/:param', 'other:thing');
-
-      expect(this.myEventRouter.getDefaultRoute('other:thing')).to.eql('other/:param');
-    });
-  });
-
-  describe('when navigating from event', function(){
-    beforeEach(function() {
-      this.myEventRouter = new Backbone.EventRouter({
-        routeTriggers: {
-          'bar:event': ['some/url/:param', 'some/url', 'other/:section/:id'],
-          'thing:list': 'other/:param'
-        }
-      });
-
-      Backbone.history.location = new this.Location('http://example.com/example');
-      Backbone.history.start();
-    });
-
-    it('should translate event to URL', function(){
-      this.myEventRouter.navigateFromEvent('bar:event', 'foo');
-
-      expect(Backbone.history.location.hash).to.equal('#some/url/foo');
-    });
-
-  });
-
-  describe('when translating route', function() {
-    beforeEach(function() {
-      this.myEventRouter = new Backbone.EventRouter();
-    });
-
-    it('should return a url with the named params replaced with the argument values', function(){
-      var translatedRoute = this.myEventRouter.translateRoute('some/url/:param/:id', ['foo', 22]);
-      expect(translatedRoute).to.eql('some/url/foo/22');
     });
   });
 });

--- a/test/unit/events.js
+++ b/test/unit/events.js
@@ -1,0 +1,128 @@
+describe('Backbone.Eventrouter Events', function() {
+  beforeEach(function() {
+    this.Location = function(href) {
+      this.replace(href);
+    };
+
+    _.extend(this.Location.prototype, {
+      parser: document.createElement('a'),
+      replace: function(href) {
+        this.parser.href = href;
+        _.extend(this, _.pick(this.parser,
+                              'href',
+                              'hash',
+                              'host',
+                              'search',
+                              'fragment',
+                              'pathname',
+                              'protocol'
+                             ));
+        // In IE, anchor.pathname does not contain a leading slash though
+        // window.location.pathname does.
+        if (!/^\//.test(this.pathname)){
+          this.pathname = '/' + this.pathname;
+        }
+      },
+      toString: function() {
+        return this.href;
+      }
+    });
+    Backbone.history.location = new this.Location('http://example.com/example');
+    this.myEventRouter = new Backbone.EventRouter();
+    this.routerChannel = this.myEventRouter.getChannel();
+
+    Backbone.history.start();
+  });
+
+  afterEach(function() {
+    Backbone.history.stop();
+  });
+
+  describe('when a route is run', function() {
+    describe('when that route is handled by the router', function() {
+      beforeEach(function() {
+        this.beforeRouteStub = this.sinon.stub();
+        this.routeStub = this.sinon.stub();
+        this.beforeRouteNameStub = this.sinon.stub();
+        this.routeNameStub = this.sinon.stub();
+
+        this.myEventRouter.on('before:route', this.beforeRouteStub);
+        this.myEventRouter.on('route', this.routeStub);
+        this.myEventRouter.on('before:route:testevent:bar', this.beforeRouteNameStub);
+        this.myEventRouter.on('route:testevent:bar', this.routeNameStub);
+
+        this.myEventRouter.addRouteTrigger('test/url/:foo', 'testevent:bar');
+        this.myEventRouter.navigate('test/url/baz', { trigger: true });
+      });
+
+      it('should throw a before:route event to match the route event', function(){
+        expect(this.beforeRouteStub).to.have.been.calledOnce;
+        expect(this.beforeRouteStub.args).to.deep.equal(this.routeStub.args);
+      });
+
+      it('should throw a before:route:[name] event to match the route:[name] event', function(){
+        expect(this.beforeRouteNameStub).to.have.been.calledOnce;
+        expect(this.beforeRouteNameStub.args).to.deep.equal(this.routeNameStub.args);
+      });
+    });
+    describe('when that route is not handled by the router', function() {
+      beforeEach(function() {
+        this.noMatchStub = this.sinon.stub();
+        this.myEventRouter.on('noMatch', this.noMatchStub);
+
+        this.myEventRouter.navigate('test/url/baz', { trigger: true });
+      });
+
+      it('should throw a noMatch event', function(){
+        expect(this.noMatchStub).to.have.been.calledOnce;
+      });
+
+      it('should pass the event args to the noMatch event', function() {
+        expect(this.noMatchStub).to.have.been.calledWith('testevent:bar', 'baz');
+      });
+    });
+  });
+
+  describe('when a event is triggered', function() {
+    describe('when that event is handled by the router', function() {
+      beforeEach(function() {
+        this.beforeRouteStub = this.sinon.stub();
+        this.routeStub = this.sinon.stub();
+        this.beforeRouteNameStub = this.sinon.stub();
+        this.routeNameStub = this.sinon.stub();
+
+        this.myEventRouter.on('before:route', this.beforeRouteStub);
+        this.myEventRouter.on('route', this.routeStub);
+        this.myEventRouter.on('before:route:testevent:bar', this.beforeRouteNameStub);
+        this.myEventRouter.on('route:testevent:bar', this.routeNameStub);
+
+        this.myEventRouter.addRouteTrigger('test/url/:foo', 'testevent:bar');
+        this.routerChannel.trigger('testevent:bar', 'baz');
+      });
+
+      it('should not throw a before:route event', function(){
+        expect(this.beforeRouteStub).to.not.have.been.called;
+      });
+
+      it('should not throw a before:route:[name] event', function(){
+        expect(this.beforeRouteNameStub).to.not.have.been.called;
+      });
+    });
+    describe('when that route is not handled by the router', function() {
+      beforeEach(function() {
+        this.noMatchStub = this.sinon.stub();
+        this.myEventRouter.on('noMatch', this.noMatchStub);
+
+        this.routerChannel.trigger('testevent:bar', 'baz');
+      });
+
+      it('should throw a noMatch event', function(){
+        expect(this.noMatchStub).to.have.been.calledOnce;
+      });
+
+      it('should pass the event args to the noMatch event', function() {
+        expect(this.noMatchStub).to.have.been.calledWith('testevent:bar', 'baz');
+      });
+    });
+  });
+});


### PR DESCRIPTION
Resolves #6 

Split up the tests by constructor / events /api

Subsequently fixed the arguments sent to `noMatch`
